### PR TITLE
➖ remove nix and use libc directly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.27", features = ["user"], default-features = false }
+libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = [


### PR DESCRIPTION
This (particular) functionality used from `nix` directly maps to `libc` calls. Using `libc` directly has the advantage of not having to update `nix` and just having less dependencies.

---

I decided to do this after noticing a duplicate dependency. Only after did I notice that nix was updated in #2, but this PR "solves" https://github.com/zeenix/xdg-home/pull/2#issuecomment-1770544101. It does add a few `unsafe` blocks, so feel free to close this if this is something you would like to avoid.