### PR TITLE
build(deps): Replace dependency `winapi` by `windows-sys`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,8 @@ readme = "README.md"
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = [
-  "combaseapi",
-  "knownfolders",
-  "shlobj",
-  "winerror",
+windows-sys = { version = "0.52", features = [
+  "Win32_Foundation",
+  "Win32_UI_Shell",
+  "Win32_System_Com",
 ] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,23 +65,15 @@ mod unix {
 mod win32 {
     use std::{path::PathBuf, ptr};
 
-    use winapi::{
-        shared::winerror::S_OK,
-        um::{
-            combaseapi::CoTaskMemFree, knownfolders::FOLDERID_Profile, shlobj::SHGetKnownFolderPath,
-        },
-    };
+    use windows_sys::Win32::Foundation::S_OK;
+    use windows_sys::Win32::System::Com::CoTaskMemFree;
+    use windows_sys::Win32::UI::Shell::FOLDERID_Profile;
+    use windows_sys::Win32::UI::Shell::SHGetKnownFolderPath;
 
     pub(super) fn home_dir() -> Option<PathBuf> {
+        let rfid = FOLDERID_Profile;
         let mut psz_path = ptr::null_mut();
-        let res = unsafe {
-            SHGetKnownFolderPath(
-                &FOLDERID_Profile,
-                0,
-                ptr::null_mut(),
-                &mut psz_path as *mut _,
-            )
-        };
+        let res = unsafe { SHGetKnownFolderPath(&rfid, 0, 0, &mut psz_path as *mut _) };
         if res != S_OK {
             return None;
         }


### PR DESCRIPTION
While reviewing my dependencies, I noticed both `winapi` and `windows-sys` in my dependency tree. Both provide a similar functionality, but `windows-sys` seems to be actively maintained by Microsoft.

Are you open to replacing this depencency? If not, please say so.

Is a version range preferred for this dependency? I found that this version range works: `version = ">= 0.32, <= 0.52"`. If so, I can add a minimal version CI build.