### PR TITLE
Remove unneeded LICENSE symlink

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,0 @@
-LICENSE-MIT


### PR DESCRIPTION
This confuses Github into thinking that we've multiple licenses.